### PR TITLE
Auction - Display latest bid (Dependent on PR #8)

### DIFF
--- a/Junk4Dollars-app/Auctions/Auction.swift
+++ b/Junk4Dollars-app/Auctions/Auction.swift
@@ -5,6 +5,25 @@ public struct Auction: Codable {
     public let description: String
     public let starting_price: Int
     public let ends_at: String
+    public var bid: Bid? = nil
+
+    public struct Bid: Codable {
+        public let price: Int
+        public let created_at: String
+    }
+
+    public init(identifier: Int, title: String, description: String, starting_price: Int, ends_at: String, bid: Bid?) {
+        self.identifier = identifier
+        self.title = title
+        self.description = description
+        self.starting_price = starting_price
+        self.ends_at = ends_at
+        if let bid = bid {
+            self.bid = Bid(price: bid.price, created_at: bid.created_at)
+        } else {
+            self.bid = nil
+        }
+    }
 
     public init(identifier: Int, title: String, description: String, starting_price: Int, ends_at: String) {
         self.identifier = identifier
@@ -20,8 +39,8 @@ public struct Auction: Codable {
         case description
         case starting_price
         case ends_at
+        case bid
     }
-
 }
 
 extension Auction: Equatable {

--- a/Junk4Dollars-app/Auctions/AuctionDetailsViewController.swift
+++ b/Junk4Dollars-app/Auctions/AuctionDetailsViewController.swift
@@ -32,7 +32,14 @@ public class AuctionDetailsViewController: UIViewController, AuctionDetailsView 
             self.auctionTitleLabel?.text = auction.title
             self.auctionDescriptionLabel?.text = auction.description
 
-            let price = Price(inCents: auction.starting_price).inDollars()
+            var price: String
+
+            if let bid = auction.bid {
+                price = Price(inCents: bid.price).inDollars()
+            } else {
+                price = Price(inCents: auction.starting_price).inDollars()
+            }
+
             self.auctionPriceLabel?.text = price
 
             let endTime = Time(utc: auction.ends_at).local()

--- a/Junk4Dollars-app/Endpoints.swift
+++ b/Junk4Dollars-app/Endpoints.swift
@@ -1,5 +1,5 @@
 public class ApiEndpoints {
-    static let apiEndpoint = production
+    static let apiEndpoint = development
 
     private
 

--- a/Junk4Dollars-appTests/Auctions/AuctionDetailsViewControllerTests.swift
+++ b/Junk4Dollars-appTests/Auctions/AuctionDetailsViewControllerTests.swift
@@ -57,4 +57,46 @@ class AuctionDetailsViewControllerTests: XCTestCase {
 
         XCTAssertEqual("11-01-2019 3:35 PM", controller.auctionTimeRemainingLabel.text)
     }
+
+    func testController_whenAuctionHasBid_setsPriceLabel_toBidPrice() {
+        let fakeAuction: Dictionary<String, Any> = [
+            "id": 1,
+            "title": "Throne of Eldraine Booster Box",
+            "description": "New: A brand-new, unused, unopened, undamaged item (including handmade items).",
+            "starting_price": 8500,
+            "ends_at": "2019-11-01T20:35:21.000Z",
+            "created_at": "2020-01-02T20:16:23.221Z",
+            "updated_at": "2020-01-02T20:16:23.221Z",
+            "user_id": 1,
+            "bid": [
+                "id": 1,
+                "price": 8699,
+                "created_at": "2020-01-03T15:50:53.993Z",
+                "updated_at": "2020-01-03T15:50:53.993Z",
+                "user_id": 3,
+                "auction_id": 1
+            ]
+        ]
+
+        apiClient.stub(responseAsJson: fakeAuction)
+        AuthenticationDependencies.authentication = authentication
+        ApiDependencies.apiServices = ApiServices(client: apiClient)
+
+        let controller = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "AuctionDetailsViewController") as! AuctionDetailsViewController
+
+        let _ = controller.view
+
+        controller.auctionId = 1
+        controller.viewDidLoad()
+        controller.viewWillAppear(true)
+
+        let expectation = XCTestExpectation()
+        DispatchQueue.main.async {
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual("$86.99", controller.auctionPriceLabel.text)
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Display latest bid price as the Auction's price

## Description
<!--- Describe your changes in detail -->
- Update Auction structure to have a nested Bid struct
- Add new initializer to Auction for when a bid is present
- Update AuctionDetailsViewController to display bid price if present

## Screenshots (if applicable)
Auction 1's price was initially `8500` ($85.00), and then received 2 bids, bringing the latest price up to `8699` ($86.99)
![Screen Shot 2020-01-03 at 2 53 10 PM](https://user-images.githubusercontent.com/1291669/71748653-da13d300-2e38-11ea-8971-65a573bd9b19.png)

Auction details view displays the latest bid price
![Screen Shot 2020-01-03 at 2 52 11 PM](https://user-images.githubusercontent.com/1291669/71748654-da13d300-2e38-11ea-8eec-1f19751322ab.png)

